### PR TITLE
Change artifactId to the normal scala version naming convention

### DIFF
--- a/scalagen/pom.xml
+++ b/scalagen/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.mysema.scalagen</groupId>
-  <artifactId>scalagen_${scala.version}</artifactId>
+  <artifactId>scalagen_${scala.repoVersion}</artifactId>
   <version>0.3.2</version>
   <name>Scalagen</name>
     
@@ -44,6 +44,7 @@
       </activation>
       <properties>
         <scala.version>2.9.3</scala.version>
+        <scala.repoVersion>2.9.3</scala.repoVersion>
         <scalaArm.scalaVersion>2.9.2</scalaArm.scalaVersion>
         <scalaArm.libVersion>1.3</scalaArm.libVersion>
         <test.scalaSourceFolder>scala29</test.scalaSourceFolder>
@@ -55,6 +56,7 @@
       <id>scala-2.10.x</id>
       <properties>
         <scala.version>2.10.1</scala.version>
+        <scala.repoVersion>2.10</scala.repoVersion>
         <scalaArm.scalaVersion>2.10</scalaArm.scalaVersion>
         <scalaArm.libVersion>1.4</scalaArm.libVersion>
         <test.scalaSourceFolder>scala210_and_up</test.scalaSourceFolder>
@@ -66,6 +68,7 @@
       <id>scala-2.11.x</id>
       <properties>
         <scala.version>2.11.6</scala.version>
+        <scala.repoVersion>2.11</scala.repoVersion>
         <scalaArm.scalaVersion>2.11</scalaArm.scalaVersion>
         <scalaArm.libVersion>1.4</scalaArm.libVersion>
         <test.scalaSourceFolder>scala210_and_up</test.scalaSourceFolder>


### PR DESCRIPTION
Right now the artifactId includes the full scala version in it, eg scalagen_2.9.3, scalagen_2.10.1, etc.
This was the convention for 2.9.x, but for 2.10+ the convention is to only have the major/minor scala version, eg scalagen_2.10.

Also, would you be able to bump the version and do a release?